### PR TITLE
Add validation for Unique Field restriction

### DIFF
--- a/src/schema-entities.ts
+++ b/src/schema-entities.ts
@@ -80,6 +80,7 @@ export interface FieldDefinition {
     regex?: string;
     script?: Array<string> | string;
     required?: boolean;
+    unique?: boolean;
     range?: RangeRestriction;
   };
   isArray?: boolean;
@@ -119,6 +120,7 @@ export enum SchemaValidationErrorTypes {
   INVALID_BY_SCRIPT = 'INVALID_BY_SCRIPT',
   INVALID_ENUM_VALUE = 'INVALID_ENUM_VALUE',
   UNRECOGNIZED_FIELD = 'UNRECOGNIZED_FIELD',
+  INVALID_BY_UNIQUE= 'INVALID_BY_UNIQUE',
 }
 
 export interface SchemaValidationError {

--- a/src/schema-error-messages.ts
+++ b/src/schema-error-messages.ts
@@ -27,6 +27,7 @@ const ERROR_MESSAGES: { [key: string]: (errorData: any) => string } = {
   INVALID_BY_SCRIPT: error => error.info.message,
   INVALID_ENUM_VALUE: () => INVALID_VALUE_ERROR_MESSAGE,
   MISSING_REQUIRED_FIELD: errorData => `${errorData.fieldName} is a required field.`,
+  INVALID_BY_UNIQUE: errorData => `Value for ${errorData.fieldName} must be unique.`
 };
 
 // Returns the formatted message for the given error key, taking any required properties from the info object

--- a/test/schema-functions.spec.ts
+++ b/test/schema-functions.spec.ts
@@ -458,7 +458,90 @@ describe('schema-functions', () => {
       info: { value: ['not_q'], regex: '^q.*$', examples: undefined },
     });
   });
+
+  it('should pass unique restriction validation when only null values exists', () => {
+    const result = schemaService.processRecords(schema, 'favorite_things', [
+      {
+        id: 'TH-ING',
+        unique_value: '',
+      },
+    ]);
+    chai.expect(result.validationErrors.length).to.eq(0);
+  });
+
+  it('should pass unique restriction validation when only one record exists', () => {
+    const result = schemaService.processRecords(schema, 'favorite_things', [
+      {
+        id: 'TH-ING',
+        unique_value: 'unique_value_1',
+      },
+    ]);
+    chai.expect(result.validationErrors.length).to.eq(0);
+  });
+
+  it('should fail unique restriction validation when duplicate values exist (scalar)', () => {
+    const result = schemaService.processRecords(schema, 'favorite_things', [
+      {
+        id: 'ID-1',
+        unique_value: 'unique_value_1',
+      },
+      {
+        id: 'ID-2',
+        unique_value: 'unique_value_1',
+      },
+    ]);
+
+    chai.expect(result.validationErrors.length).to.eq(2);
+    chai.expect(result.validationErrors[0]).to.deep.eq({
+      errorType: SchemaValidationErrorTypes.INVALID_BY_UNIQUE,
+      message:
+        'Value for unique_value must be unique.',
+      fieldName: 'unique_value',
+      index: 0,
+      info: { value: ['unique_value_1'] },
+    });
+    chai.expect(result.validationErrors[1]).to.deep.eq({
+      errorType: SchemaValidationErrorTypes.INVALID_BY_UNIQUE,
+      message:
+        'Value for unique_value must be unique.',
+      fieldName: 'unique_value',
+      index: 1,
+      info: { value: ['unique_value_1'] },
+    });
+  });
+  it('should fail unique restriction validation when duplicate values exist (array)', () => {
+    const result = schemaService.processRecords(schema, 'favorite_things', [
+      {
+        id: 'ID-1',
+        unique_value: ['unique_value_1', 'unique_value_2'],
+      },
+      {
+        id: 'ID-2',
+        unique_value: ['unique_value_1', 'unique_value_2'],
+      },
+    ]);
+
+    chai.expect(result.validationErrors.length).to.eq(2);
+    chai.expect(result.validationErrors[0]).to.deep.eq({
+      errorType: SchemaValidationErrorTypes.INVALID_BY_UNIQUE,
+      message:
+        'Value for unique_value must be unique.',
+      fieldName: 'unique_value',
+      index: 0,
+      info: { value: ['unique_value_1', 'unique_value_2'] },
+    });
+    chai.expect(result.validationErrors[1]).to.deep.eq({
+      errorType: SchemaValidationErrorTypes.INVALID_BY_UNIQUE,
+      message:
+        'Value for unique_value must be unique.',
+      fieldName: 'unique_value',
+      index: 1,
+      info: { value: ['unique_value_1', 'unique_value_2'] },
+    });
+  });
 });
+
+
 
 const records = [
   {

--- a/test/schema.json
+++ b/test/schema.json
@@ -330,6 +330,13 @@
             "description": "integers between -10 and 10",
             "restrictions": { "required": false, "range": { "max": 10, "min": -10 } },
             "isArray": true
+          },
+          {
+            "name": "unique_value",
+            "valueType": "string",
+            "description": "unique value",
+            "restrictions": { "required": false, "unique": true },
+            "isArray": true
           }
         ]
       }


### PR DESCRIPTION
Resolves [#32](https://github.com/overture-stack/js-lectern-client/issues/32)

This is a proposed implementation for Lectern's `unique` restriction validation. It's the first of a set of "relational validation" functions, which apply to a dataset instead of individual records, as the current validations.


## Summary of changes
- New type `TypedDatasetValidationFunction` to describe functions that apply to a dataset.
- New function `runDatasetValidationPipeline` to apply a set of `TypedDatasetValidationFunction` functions.
- New function `validateRecordsSet` calls the validation pipeline once all records have their types converted and have been validated with the functions that validate individual records. 