### PR TITLE
Add foreignKey validation for a full dictionary

### DIFF
--- a/src/records-operations.ts
+++ b/src/records-operations.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import _ from 'lodash';
+
+/**
+ * Calculates the difference between 2 records (similar to a set difference). Returns rows in `recordA` which are not present
+ * in `recordB`. Two rows are equal if their values are the same.
+ * @param recordA Record A. The returned value of this function is a subset of this record.
+ * @param recordB Record B. Elements to be substracted from Record A.
+ */
+export const calculateDifference = (recordA: Record<number, string[]>, recordB: Record<number, string[]>): any[][]  => {
+    const arrayA = recordToArray(recordA);
+    const arrayB = recordToArray(recordB);
+    return _.differenceWith(arrayA, arrayB, (a, b) => a[1].join('_') == b[1].join('_'));
+  };
+
+const recordToArray = (record: Record<number, string[]>): any[] => {
+    return Object.keys(record).map(x => {
+        const idx = parseInt(x);
+        return [idx, record[idx]];
+    });
+};

--- a/src/records-operations.ts
+++ b/src/records-operations.ts
@@ -17,7 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import _ from 'lodash';
+import { differenceWith } from 'lodash';
 
 /**
  * Calculates the difference between 2 records (similar to a set difference). Returns rows in `recordA` which are not present
@@ -28,7 +28,7 @@ import _ from 'lodash';
 export const calculateDifference = (recordA: Record<number, string[]>, recordB: Record<number, string[]>): any[][]  => {
     const arrayA = recordToArray(recordA);
     const arrayB = recordToArray(recordB);
-    return _.differenceWith(arrayA, arrayB, (a, b) => a[1].join('_') == b[1].join('_'));
+    return differenceWith(arrayA, arrayB, (a, b) => a[1].join('_') === b[1].join('_'));
   };
 
 const recordToArray = (record: Record<number, string[]>): any[] => {

--- a/src/schema-entities.ts
+++ b/src/schema-entities.ts
@@ -40,6 +40,7 @@ export interface SchemasDictionary {
 export interface SchemaDefinition {
   readonly name: string;
   readonly description: string;
+  readonly restrictions: SchemaRestriction;
   readonly fields: ReadonlyArray<FieldDefinition>;
 }
 
@@ -52,6 +53,8 @@ export interface FieldDiff {
   after?: FieldDefinition;
   diff: FieldChanges;
 }
+
+export type SchemaData = ReadonlyArray<DataRecord>;
 
 // changes can be nested
 // in case of created/delete field we get Change
@@ -68,6 +71,17 @@ export enum ChangeTypeName {
 export interface Change {
   type: ChangeTypeName;
   data: any;
+}
+
+export interface SchemaRestriction {
+  foreignKey?: {
+    schema: string;
+    mappings: {
+      local: string;
+      foreign: string;
+    }[];
+  }[] | undefined;
+  uniqueKey?: string[] | undefined;
 }
 
 export interface FieldDefinition {
@@ -120,7 +134,8 @@ export enum SchemaValidationErrorTypes {
   INVALID_BY_SCRIPT = 'INVALID_BY_SCRIPT',
   INVALID_ENUM_VALUE = 'INVALID_ENUM_VALUE',
   UNRECOGNIZED_FIELD = 'UNRECOGNIZED_FIELD',
-  INVALID_BY_UNIQUE= 'INVALID_BY_UNIQUE',
+  INVALID_BY_UNIQUE = 'INVALID_BY_UNIQUE',
+  INVALID_BY_FOREIGN_KEY = 'INVALID_BY_FOREIGN_KEY',
 }
 
 export interface SchemaValidationError {

--- a/src/schema-entities.ts
+++ b/src/schema-entities.ts
@@ -80,8 +80,8 @@ export interface SchemaRestriction {
       local: string;
       foreign: string;
     }[];
-  }[] | undefined;
-  uniqueKey?: string[] | undefined;
+  }[];
+  uniqueKey?: string[];
 }
 
 export interface FieldDefinition {

--- a/src/schema-error-messages.ts
+++ b/src/schema-error-messages.ts
@@ -17,10 +17,19 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import { isArray } from 'lodash';
 import { RangeRestriction } from './schema-entities';
 
 function getForeignKeyErrorMsg(errorData: any) {
-  const valuesAsString = errorData.info.value.join(', ');
+  const valueEntries = Object.entries(errorData.info.value);
+  const formattedKeyValues: string[] = valueEntries.map(([key, value]) => {
+    if (isArray(value)) {
+      return `${key}: [${value.join(', ')}]`;
+    } else {
+      return `${key}: ${value}`;
+    }
+  });
+  const valuesAsString = formattedKeyValues.join(', ');
   const detail = `Key ${valuesAsString} is not present in schema ${errorData.info.foreignSchema}`;
   const msg = `Record violates foreign key restriction defined for field(s) ${errorData.fieldName}. ${detail}.`;
   return msg;

--- a/src/schema-error-messages.ts
+++ b/src/schema-error-messages.ts
@@ -27,7 +27,8 @@ const ERROR_MESSAGES: { [key: string]: (errorData: any) => string } = {
   INVALID_BY_SCRIPT: error => error.info.message,
   INVALID_ENUM_VALUE: () => INVALID_VALUE_ERROR_MESSAGE,
   MISSING_REQUIRED_FIELD: errorData => `${errorData.fieldName} is a required field.`,
-  INVALID_BY_UNIQUE: errorData => `Value for ${errorData.fieldName} must be unique.`
+  INVALID_BY_UNIQUE: errorData => `Value for ${errorData.fieldName} must be unique.`,
+  INVALID_BY_FOREIGN_KEY: errorData => getForeignKeyErrorMsg(errorData),
 };
 
 // Returns the formatted message for the given error key, taking any required properties from the info object
@@ -68,6 +69,13 @@ function getRegexErrorMsg(info: any) {
   if (info.examples) {
     msg = msg + ` Examples: ${info.examples}`;
   }
+  return msg;
+}
+
+function getForeignKeyErrorMsg(errorData: any) {
+  const valuesAsString = errorData.info.value.join(', ');
+  const detail = `Key ${valuesAsString} is not present in schema ${errorData.info.foreignSchema}`;
+  const msg = `Record violates foreign key restriction defined for field(s) ${errorData.fieldName}. ${detail}.`;
   return msg;
 }
 

--- a/src/schema-error-messages.ts
+++ b/src/schema-error-messages.ts
@@ -19,6 +19,13 @@
 
 import { RangeRestriction } from './schema-entities';
 
+function getForeignKeyErrorMsg(errorData: any) {
+  const valuesAsString = errorData.info.value.join(', ');
+  const detail = `Key ${valuesAsString} is not present in schema ${errorData.info.foreignSchema}`;
+  const msg = `Record violates foreign key restriction defined for field(s) ${errorData.fieldName}. ${detail}.`;
+  return msg;
+}
+
 const INVALID_VALUE_ERROR_MESSAGE = 'The value is not permissible for this field.';
 const ERROR_MESSAGES: { [key: string]: (errorData: any) => string } = {
   INVALID_FIELD_VALUE_TYPE: () => INVALID_VALUE_ERROR_MESSAGE,
@@ -69,13 +76,6 @@ function getRegexErrorMsg(info: any) {
   if (info.examples) {
     msg = msg + ` Examples: ${info.examples}`;
   }
-  return msg;
-}
-
-function getForeignKeyErrorMsg(errorData: any) {
-  const valuesAsString = errorData.info.value.join(', ');
-  const detail = `Key ${valuesAsString} is not present in schema ${errorData.info.foreignSchema}`;
-  const msg = `Record violates foreign key restriction defined for field(s) ${errorData.fieldName}. ${detail}.`;
   return msg;
 }
 

--- a/test/schema-functions.spec.ts
+++ b/test/schema-functions.spec.ts
@@ -539,8 +539,198 @@ describe('schema-functions', () => {
       info: { value: ['unique_value_1', 'unique_value_2'] },
     });
   });
-});
 
+  it('should pass foreignKey restriction validation when values exist in foreign schema', () => {
+    
+    const parent_schema_1_data = [
+      {
+        id: 'parent_schema_1_id_1',
+        name: 'parent_schema_1_name_1'
+      },
+      {
+        id: 'parent_schema_1_id_2',
+        name: 'parent_schema_1_name_2'
+      }
+    ];
+    
+    const child_schema_simple_fk_data =  [
+      {
+        id: '1',
+        parent_schema_1_id: 'parent_schema_1_id_1',
+      },
+      {
+        id: '2',
+        parent_schema_1_id: 'parent_schema_1_id_2',
+      }
+    ];
+    const schemaData = {
+      'parent_schema_1': parent_schema_1_data,
+      'child_schema_simple_fk': child_schema_simple_fk_data};
+
+    const result = schemaService.processSchemas(schema, schemaData);
+
+    chai.expect(result['parent_schema_1'].validationErrors.length).to.eq(0);
+    chai.expect(result['child_schema_simple_fk'].validationErrors.length).to.eq(0);
+  });
+  
+  it('should pass foreignKey restriction validation when local schema has null values', () => {
+    const parent_schema_1_data = [
+      {
+        id: 'parent_schema_1_id_1',
+        name: 'parent_schema_1_name_1'
+      },
+      {
+        id: 'parent_schema_1_id_2',
+        name: 'parent_schema_1_name_2'
+      }
+    ];
+
+    const child_schema_simple_fk_data = [
+      {
+        id: '1',
+        parent_schema_1_id: 'parent_schema_1_id_1',
+      },
+      {
+        id: '2',
+        parent_schema_1_id: '',
+      }
+    ];
+    const schemaData = {
+      'parent_schema_1': parent_schema_1_data,
+      'child_schema_simple_fk': child_schema_simple_fk_data
+    };
+
+    const result = schemaService.processSchemas(schema, schemaData);
+
+    chai.expect(result['parent_schema_1'].validationErrors.length).to.eq(0);
+    chai.expect(result['child_schema_simple_fk'].validationErrors.length).to.eq(0);
+  });
+
+  it('should pass foreignKey restriction validation when values exist in foreign schema (composite fk)', () => {
+    
+    const parent_schema_1_data = [
+      {
+        id: 'parent_schema_1_id_1',
+        external_id: 'parent_schema_1_external_id_1',
+        name: 'parent_schema_1_name_1'
+      },
+      {
+        id: 'parent_schema_1_id_2',
+        external_id: 'parent_schema_1_external_id_2',
+        name: 'parent_schema_1_name_2'
+      }
+    ];
+    
+    const child_schema_composite_fk_data =  [
+      {
+        id: '1',
+        parent_schema_1_id: 'parent_schema_1_id_1',
+        parent_schema_1_external_id: 'parent_schema_1_external_id_1',
+      },
+      {
+        id: '2',
+        parent_schema_1_id: 'parent_schema_1_id_2',
+        parent_schema_1_external_id: 'parent_schema_1_external_id_2',
+      }
+    ];
+    const schemaData = {
+      'parent_schema_1': parent_schema_1_data,
+      'child_schema_composite_fk': child_schema_composite_fk_data};
+
+    const result = schemaService.processSchemas(schema, schemaData);
+
+    chai.expect(result['parent_schema_1'].validationErrors.length).to.eq(0);
+    chai.expect(result['child_schema_composite_fk'].validationErrors.length).to.eq(0);
+  });
+
+  it('should fail foreignKey restriction validation when value does not exist in foreign schema', () => {
+    
+    const parent_schema_1_data = [
+      {
+        id: 'parent_schema_1_id_1',
+        name: 'parent_schema_1_name_1'
+      },
+      {
+        id: 'parent_schema_1_id_2',
+        name: 'parent_schema_1_name_2'
+      }
+    ];
+    
+    const child_schema_simple_fk_data =  [
+      {
+        id: '1',
+        parent_schema_1_id: 'parent_schema_1_id_1',
+      },
+      {
+        id: '2',
+        parent_schema_1_id: 'non_existing_value_in_foreign_schema',
+      }
+    ];
+    const schemaData = {
+      'parent_schema_1': parent_schema_1_data,
+      'child_schema_simple_fk': child_schema_simple_fk_data};
+
+    const result = schemaService.processSchemas(schema, schemaData);
+    const childSchemaErrors = result['child_schema_simple_fk'].validationErrors;
+
+    chai.expect(childSchemaErrors.length).to.eq(1);
+    chai.expect(childSchemaErrors[0]).to.deep.eq({
+      errorType: SchemaValidationErrorTypes.INVALID_BY_FOREIGN_KEY,
+      message:
+        'Record violates foreign key restriction defined for field(s) parent_schema_1_id. Key non_existing_value_in_foreign_schema is not present in schema parent_schema_1.',
+      fieldName: 'parent_schema_1_id',
+      index: 1,
+      info: { "foreignSchema": "parent_schema_1", value: ['non_existing_value_in_foreign_schema'] },
+    });
+
+  });
+
+  it('should fail foreignKey restriction validation when values do not exist in foreign schema (composite fk)', () => {
+    
+    const parent_schema_1_data = [
+      {
+        id: 'parent_schema_1_id_1',
+        external_id: 'parent_schema_1_external_id_1',
+        name: 'parent_schema_1_name_1'
+      },
+      {
+        id: 'parent_schema_1_id_2',
+        external_id: 'parent_schema_1_external_id_2',
+        name: 'parent_schema_1_name_2'
+      }
+    ];
+    
+    const child_schema_composite_fk_data =  [
+      {
+        id: '1',
+        parent_schema_1_id: 'parent_schema_1_id_1',
+        parent_schema_1_external_id: 'parent_schema_1_external_id_1',
+      },
+      {
+        id: '2',
+        parent_schema_1_id: 'parent_schema_1_id_2',
+        parent_schema_1_external_id: 'non_existing_value_in_foreign_schema',
+      }
+    ];
+    const schemaData = {
+      'parent_schema_1': parent_schema_1_data,
+      'child_schema_composite_fk': child_schema_composite_fk_data};
+
+    const result = schemaService.processSchemas(schema, schemaData);
+    const childSchemaErrors = result['child_schema_composite_fk'].validationErrors;
+
+    chai.expect(childSchemaErrors.length).to.eq(1);
+    chai.expect(childSchemaErrors[0]).to.deep.eq({
+      errorType: SchemaValidationErrorTypes.INVALID_BY_FOREIGN_KEY,
+      message:
+        'Record violates foreign key restriction defined for field(s) parent_schema_1_id, parent_schema_1_external_id. Key parent_schema_1_id_2, non_existing_value_in_foreign_schema is not present in schema parent_schema_1.',
+      fieldName: 'parent_schema_1_id, parent_schema_1_external_id',
+      index: 1,
+      info: { "foreignSchema": "parent_schema_1", value: ['parent_schema_1_id_2', 'non_existing_value_in_foreign_schema'] },
+    });
+  });
+
+});
 
 
 const records = [

--- a/test/schema.json
+++ b/test/schema.json
@@ -366,14 +366,16 @@
         "description": "Parent schema 1. Used to test relational validations",
         "fields": [
           {
-            "name": "id",
+            "name": "id1",
             "valueType": "string",
-            "description": "Id"
+            "description": "Id 1",
+            "isArray": true
           },
           {
-            "name": "name",
+            "name": "id2",
             "valueType": "string",
-            "description": "Name"
+            "description": "Id 2",
+            "isArray": true
           }
         ]
       },
@@ -441,6 +443,46 @@
             "name": "parent_schema_1_external_id",
             "valueType": "string",
             "description": "Reference to external id in schema parent_schema_1"
+          }
+        ]
+      },
+      {
+        "name": "child_schema_composite_array_values_fk",
+        "description": "Child schema referencing several fields in a foreign schema",
+        "restrictions": { 
+            "foreignKey":[
+                {
+                    "schema": "parent_schema_2",
+                    "mappings": [
+                        {
+                            "local": "parent_schema_2_id1", 
+                            "foreign": "id1"
+                        },
+                        {
+                          "local": "parent_schema_2_id12", 
+                          "foreign": "id2"
+                      }
+                    ]
+                }
+            ]
+        },
+        "fields": [
+          {
+            "name": "id",
+            "valueType": "number",
+            "description": "Id"
+          },
+          {
+            "name": "parent_schema_2_id1",
+            "valueType": "string",
+            "description": "Reference to id1 in schema parent_schema_2",
+            "isArray": true
+          },
+          {
+            "name": "parent_schema_2_id12",
+            "valueType": "string",
+            "description": "Reference to external id2 in schema parent_schema_2",
+            "isArray": true
           }
         ]
       }

--- a/test/schema.json
+++ b/test/schema.json
@@ -339,6 +339,110 @@
             "isArray": true
           }
         ]
+      },
+      {
+        "name": "parent_schema_1",
+        "description": "Parent schema 1. Used to test relational validations",
+        "fields": [
+          {
+            "name": "id",
+            "valueType": "string",
+            "description": "Id"
+          },
+          {
+            "name": "external_id",
+            "valueType": "string",
+            "description": "External Id"
+          },
+          {
+            "name": "name",
+            "valueType": "string",
+            "description": "Name"
+          }
+        ]
+      },
+      {
+        "name": "parent_schema_2",
+        "description": "Parent schema 1. Used to test relational validations",
+        "fields": [
+          {
+            "name": "id",
+            "valueType": "string",
+            "description": "Id"
+          },
+          {
+            "name": "name",
+            "valueType": "string",
+            "description": "Name"
+          }
+        ]
+      },
+      {
+        "name": "child_schema_simple_fk",
+        "description": "Child schema referencing a field in a foreign schema",
+        "restrictions": { 
+            "foreignKey":[
+                {
+                    "schema": "parent_schema_1",
+                    "mappings": [
+                        {
+                            "local": "parent_schema_1_id", 
+                            "foreign": "id"
+                        }
+                    ]
+                }
+            ]
+        },
+        "fields": [
+          {
+            "name": "id",
+            "valueType": "number",
+            "description": "Id"
+          },
+          {
+            "name": "parent_schema_1_id",
+            "valueType": "string",
+            "description": "Reference to id in schema parent_schema_1"
+          }
+        ]
+      },
+      {
+        "name": "child_schema_composite_fk",
+        "description": "Child schema referencing several fields in a foreign schema",
+        "restrictions": { 
+            "foreignKey":[
+                {
+                    "schema": "parent_schema_1",
+                    "mappings": [
+                        {
+                            "local": "parent_schema_1_id", 
+                            "foreign": "id"
+                        },
+                        {
+                          "local": "parent_schema_1_external_id", 
+                          "foreign": "external_id"
+                      }
+                    ]
+                }
+            ]
+        },
+        "fields": [
+          {
+            "name": "id",
+            "valueType": "number",
+            "description": "Id"
+          },
+          {
+            "name": "parent_schema_1_id",
+            "valueType": "string",
+            "description": "Reference to id in schema parent_schema_1"
+          },
+          {
+            "name": "parent_schema_1_external_id",
+            "valueType": "string",
+            "description": "Reference to external id in schema parent_schema_1"
+          }
+        ]
       }
     ],
     "_id": "5d250369f38d1f0d9376fd38",


### PR DESCRIPTION
Resolves [#35](https://github.com/overture-stack/js-lectern-client/issues/35)

This is an implementation proposal for the validation of foreign keys between schemas. It validates that a field or set of fields (equivalent to a composite fk in relational databases) matches at least one record in a record in another schema.

## Summary of main changes

- New `processSchemas` function to validate schemas data against a dictionary. It calls `processRecords` to run validations per schema but also runs a cross-schema validation pipeline.
- New `runCrossSchemaValidationPipeline` function, homologous to `runValidationPipeline`, to run validation functions of type `CrossSchemaValidationFunction`
- New type `CrossSchemaValidationFunction` to describe functions that apply over a full dictionary.
