### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
+> **Deprecation Notice**
+> 
+> This version of the Lectern client is considered deprecated. The officially supported version has been moved to [@overture-stack/lectern-client](https://www.npmjs.com/package/@overture-stack/lectern-client) alongside the other [Overture.bio](https://www.overture.bio/) software packages.
+> 
+> The Lectern client codebase has also been moved. To find the latest version of this tool please go to [github.com/@overture-stack/lectern](https://github.com/overture-stack/lectern).
+
 # JS Lectern Client 
-
-## Deprecation Notice
-This version of the Lectern client is considered deprecated. The officially supported version has been moved to [@overture-stack/lectern-client](https://www.npmjs.com/package/@overture-stack/lectern-client) alongside the other [Overture.bio](https://www.overture.bio/) software packages.
-
-The Lectern Client codebase has also been moved. To find the latest version of this tool please go to [github.com/@overture-stack/lectern](https://github.com/overture-stack/lectern).
 
 ## Features:
 - Runs different restrictions validations: regex, range, scripts, required fields, type checks, etc.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > 
 > This version of the Lectern client is considered deprecated. The officially supported version has been moved to [@overture-stack/lectern-client](https://www.npmjs.com/package/@overture-stack/lectern-client) alongside the other [Overture.bio](https://www.overture.bio/) software packages.
 > 
-> The Lectern client codebase has also been moved. To find the latest version of this tool please go to [github.com/@overture-stack/lectern](https://github.com/overture-stack/lectern).
+> The Lectern client codebase has also been moved. To contribute to the ongoing development of Lectern tools please go to [github.com/@overture-stack/lectern](https://github.com/overture-stack/lectern).
 
 # JS Lectern Client 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # JS Lectern Client 
 
+## Deprecation Notice
+This version of the Lectern client is considered deprecated. The officially supported version has been moved to [@overture-stack/lectern-client](https://www.npmjs.com/package/@overture-stack/lectern-client) alongside the other [Overture.bio](https://www.overture.bio/) software packages.
+
+The Lectern Client codebase has also been moved. To find the latest version of this tool please go to [github.com/@overture-stack/lectern](https://github.com/overture-stack/lectern).
+
 ## Features:
 - Runs different restrictions validations: regex, range, scripts, required fields, type checks, etc.
 - Transforms the data from string to their proper type.


### PR DESCRIPTION
> [!IMPORTANT]
> Before merging this PR we require the updated Lectern Client to be published to NPM. At time of writing this notice the code has been successfully migrated but not released under the updated NPM organization (`@overture-stack`).

Adds a deprecation notice to the main README. This is intended to be seen from both the published [NPMJS page](https://www.npmjs.com/package/@overturebio-stack/lectern-client) and from this github repository. 

The code has been copied into the Lectern monorepo and is undergoing significant refactoring and revision over there, so changes we plan to also archive this repository once the deprecation notice is in place.